### PR TITLE
Add a Seaside 3-compatible implementation of Partial Continuations for Dolphin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,13 @@
 * text=auto
 
+# If files are downloaded using git on Mac or Linux, then saving a package from Windows
+# will create a number of false-positive changes (files that differ only in line endings).
+
+*.pac eol=crlf
+*.pax eol=crlf
+*.st  eol=crlf
+*.cls eol=crlf
+
 *.cls linguist-language=Smalltalk
 *.st linguist-language=Smalltalk
 *.pax linguist-language=Smalltalk

--- a/Daniel S/AbstractPartialProcessCopier.cls
+++ b/Daniel S/AbstractPartialProcessCopier.cls
@@ -1,0 +1,35 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+ProcessCopier subclass: #AbstractPartialProcessCopier
+	instanceVariableNames: 'baseFrame seamIndex indexMap'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractPartialProcessCopier guid: (GUID fromString: '{d0363cda-a901-43a0-bb19-d5d6308b3385}')!
+AbstractPartialProcessCopier comment: ''!
+!AbstractPartialProcessCopier categoriesForClass!Unclassified! !
+!AbstractPartialProcessCopier methodsFor!
+
+copyObject: anObject
+	^copied at: anObject
+		ifAbsent: 
+			[((self indexOf: anObject) between: 1 and: seamIndex)
+				ifTrue: [copied at: anObject put: anObject]
+				ifFalse: 
+					[| copy |
+					copy := anObject copyForProcessCopier.
+					copied at: anObject put: copy.
+					copy deepenProcessCopy: self.
+					copy]].!
+
+indexOf: anObject 
+	^indexMap at: anObject ifAbsent: [0]
+	"1 to: source size do: [:i | (source at: i) == anObject ifTrue: [^i]].
+	^0"!
+
+initializeIndexMap
+	self subclassResponsibility! !
+!AbstractPartialProcessCopier categoriesFor: #copyObject:!copying!public! !
+!AbstractPartialProcessCopier categoriesFor: #indexOf:!public! !
+!AbstractPartialProcessCopier categoriesFor: #initializeIndexMap!public! !
+

--- a/Daniel S/ContinuationDelimiterRequest.cls
+++ b/Daniel S/ContinuationDelimiterRequest.cls
@@ -1,0 +1,29 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Notification subclass: #ContinuationDelimiterRequest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ContinuationDelimiterRequest guid: (GUID fromString: '{6d45b258-c8f5-4b5d-b205-590154a8ea2d}')!
+ContinuationDelimiterRequest comment: ''!
+!ContinuationDelimiterRequest categoriesForClass!Unclassified! !
+!ContinuationDelimiterRequest methodsFor!
+
+defaultAction
+	^nil.!
+
+tryBlockFrame
+	| proc markAndTryFrame |
+	proc := Processor activeProcess.
+	markAndTryFrame := proc 
+				frameAtAddress: (_activeHandler instVarNamed: 'returnContinuation') home outer.
+	2 to: 10
+		do: 
+			[:i | 
+			(((proc at: markAndTryFrame sp + i) isKindOf: CompiledCode) 
+				and: [(Array with: Context with: BlockClosure) includes: (proc at: markAndTryFrame sp + i + 1) class]) 
+					ifTrue: [^proc frameAtIndex: markAndTryFrame sp + i]]! !
+!ContinuationDelimiterRequest categoriesFor: #defaultAction!public! !
+!ContinuationDelimiterRequest categoriesFor: #tryBlockFrame!public! !
+

--- a/Daniel S/DS Partial Continuations.pax
+++ b/Daniel S/DS Partial Continuations.pax
@@ -1,0 +1,190 @@
+| package |
+package := Package name: 'DS Partial Continuations'.
+package paxVersion: 1;
+	basicComment: 'Partial Continuations support for Dolphin Smalltalk
+Copyright (c) 2014 Daniel Slomovits. Portions copyright (c) 2014 Shoshana Technologies, Inc., released with permission.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.'.
+
+package basicPackageVersion: '0.006'.
+
+
+package classNames
+	add: #AbstractPartialProcessCopier;
+	add: #ContinuationDelimiterRequest;
+	add: #ExceptionHandlerChainCookie;
+	add: #PartialContinuation;
+	add: #PartialContinuationTest;
+	add: #PartialProcessCopier;
+	add: #ProcessPatcher;
+	yourself.
+
+package methodNames
+	add: #BlockClosure -> #ifCurtailed:thenSignal:;
+	add: #Exception -> #acceptProcessCopier:;
+	add: #Exception -> #copyForProcessCopier;
+	add: #Exception -> #deepenProcessCopy:;
+	add: #ExceptionHandlerAbstract -> #setOuter:;
+	add: #Object -> #callcc:;
+	add: #Object -> #copyForProcessCopier;
+	add: #Object -> #mark:;
+	add: #Process -> #copyFrom:to:;
+	add: #Process -> #fixSuspendedFrame;
+	add: #StackFrame -> #receiver:;
+	yourself.
+
+package binaryGlobalNames: (Set new
+	yourself).
+
+package globalAliases: (Set new
+	yourself).
+
+package setPrerequisites: (IdentitySet new
+	add: '..\..\Core\Object Arts\Dolphin\Base\Dolphin';
+	add: '..\..\Core\Object Arts\Dolphin\System\Continuations\Dolphin Continuations';
+	add: '..\..\Core\Contributions\Camp Smalltalk\SUnit\SUnit';
+	yourself).
+
+package!
+
+"Class Definitions"!
+
+Object subclass: #ExceptionHandlerChainCookie
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+Object subclass: #PartialContinuation
+	instanceVariableNames: 'partialProcess'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+Notification subclass: #ContinuationDelimiterRequest
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ProcessCopier subclass: #AbstractPartialProcessCopier
+	instanceVariableNames: 'baseFrame seamIndex indexMap'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractPartialProcessCopier subclass: #PartialProcessCopier
+	instanceVariableNames: 'topFrame'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+AbstractPartialProcessCopier subclass: #ProcessPatcher
+	instanceVariableNames: 'patchFrames'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+TestCase subclass: #PartialContinuationTest
+	instanceVariableNames: 'crossKK counter'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+
+"Global Aliases"!
+
+
+"Loose Methods"!
+
+!BlockClosure methodsFor!
+
+ifCurtailed: terminationBlock thenSignal: aSemaphore 
+	"Never called directly. Appears out of nowhere via direct stack manipulation inside ProcessPatcher>>#unwindExistingStack.
+	aSemaphore is used to return control to the ProcessPatcher before this frame is fully unwound. If terminationBlock contains a non-local return
+	(literally never happens in base code, unless there's an exception throw somewhere), the ProcessPatcher will recognize this and return control to us"
+
+	^self valueOnUnwind: [:retValue :retFrame | terminationBlock ensure: [aSemaphore signal]].! !
+!BlockClosure categoriesFor: #ifCurtailed:thenSignal:!not restartable!public!unwinding! !
+
+!Exception methodsFor!
+
+acceptProcessCopier: aProcessCopier 
+	"Needed if and only if you want to be able to take a continuation inside an exception *handler* block and have it restore properly. Capture and restore inside guarded blocks works fine.
+	i.e. self mark: [
+		[self someOperation.
+		self callcc: [:cc | kk := cc. 'This is okay'].
+		self someOtherOperation] on: Warning
+				do: [:ex | (self callcc: 
+							[:cc | 
+							errKK := cc. 'This would not be'.
+							false]) ifTrue: [ex resume]]]"
+
+	^aProcessCopier copyObject: self!
+
+copyForProcessCopier
+	"See #acceptProcessCopier: -- we need to not nil our instance variables for state-saving to work correctly..."
+
+	^self shallowCopy!
+
+deepenProcessCopy: aProcessCopier
+	"See #acceptProcessCopier:.
+	Easiest to just blindly 'copy' all our instance variables, some of which are primitive types that won't be copied.
+	_signalFrame is really a pointer and needs to be 'copied' too."
+
+	1 to: self class instSize
+		do: [:i | (self instVarAt: i) ifNotNil: [:a | self instVarAt: i put: (aProcessCopier visit: a)]].
+	(_signalFrame isNil or: [_signalFrame isZero])
+		ifFalse: [_signalFrame := _signalFrame + aProcessCopier delta].! !
+!Exception categoriesFor: #acceptProcessCopier:!public! !
+!Exception categoriesFor: #copyForProcessCopier!public! !
+!Exception categoriesFor: #deepenProcessCopy:!public! !
+
+!ExceptionHandlerAbstract methodsFor!
+
+setOuter: anExceptionHandler 
+	outer := anExceptionHandler! !
+!ExceptionHandlerAbstract categoriesFor: #setOuter:!public! !
+
+!Object methodsFor!
+
+callcc: aBlock 
+	^PartialContinuation currentDo: aBlock!
+
+copyForProcessCopier
+	^self copy!
+
+mark: aBlock
+	| homeFrame |
+	homeFrame := Processor activeProcess topFrame.
+	^aBlock on: ContinuationDelimiterRequest do: [:ex | ex resume: homeFrame].! !
+!Object categoriesFor: #callcc:!public! !
+!Object categoriesFor: #copyForProcessCopier!public! !
+!Object categoriesFor: #mark:!public! !
+
+!Process methodsFor!
+
+copyFrom: topFrame to: bottomFrame
+	| answer |
+	answer := PartialProcessCopier copyStackFrom: topFrame to: bottomFrame.
+	self isActive ifTrue: [answer fixSuspendedFrame].
+	^answer.!
+
+fixSuspendedFrame
+	| suspended sp |
+	suspended := self suspendedFrame.
+	sp := suspended sp + 1.
+	self
+		resize: sp;
+		at: sp put: self.
+	suspended sp: sp.! !
+!Process categoriesFor: #copyFrom:to:!public! !
+!Process categoriesFor: #fixSuspendedFrame!copying!public! !
+
+!StackFrame methodsFor!
+
+receiver: anObject 
+	"Change the `self` of the context -- DANGER"
+
+	^process at: self bp - 1 put: anObject! !
+!StackFrame categoriesFor: #receiver:!accessing!private! !
+
+"End of package definition"!
+

--- a/Daniel S/ExceptionHandlerChainCookie.cls
+++ b/Daniel S/ExceptionHandlerChainCookie.cls
@@ -1,0 +1,24 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Object subclass: #ExceptionHandlerChainCookie
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ExceptionHandlerChainCookie guid: (GUID fromString: '{2f0f24b3-1138-4c10-a890-2dc21e57ad4e}')!
+ExceptionHandlerChainCookie comment: 'Not really a class, just a placeholder object that needs some behavior. Used by PartialProcessCopier/ProcessPatcher to indicate ''whatever ExceptionHandler is below this point in the stack'''!
+!ExceptionHandlerChainCookie categoriesForClass!Kernel-Objects! !
+!ExceptionHandlerChainCookie class methodsFor!
+
+acceptProcessCopier: aProcessCopier 
+	^aProcessCopier copyObject: self.!
+
+deepenProcessCopy: aProcessCopier 
+	self error: 'Should never hit this method'.!
+
+new
+	self shouldNotImplement.! !
+!ExceptionHandlerChainCookie class categoriesFor: #acceptProcessCopier:!public! !
+!ExceptionHandlerChainCookie class categoriesFor: #deepenProcessCopy:!public! !
+!ExceptionHandlerChainCookie class categoriesFor: #new!public! !
+

--- a/Daniel S/PartialContinuation.cls
+++ b/Daniel S/PartialContinuation.cls
@@ -1,0 +1,63 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+Object subclass: #PartialContinuation
+	instanceVariableNames: 'partialProcess'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+PartialContinuation guid: (GUID fromString: '{d35c7398-052d-48be-b020-4a69c24b23eb}')!
+PartialContinuation comment: ''!
+!PartialContinuation categoriesForClass!Unclassified! !
+!PartialContinuation methodsFor!
+
+initializeFrom: topFrame to: bottomFrame 
+	self initialize.
+	partialProcess := topFrame process copyFrom: topFrame to: bottomFrame!
+
+numArgs
+	^1.!
+
+value
+	^self value: nil.!
+
+value: anObject
+	| marker |
+	marker := ContinuationDelimiterRequest signal ifNil: [Processor activeProcess topFrame sender].
+	
+	[| answerProcess |
+	answerProcess := marker process.
+	answerProcess suspend.
+	ProcessPatcher patch: partialProcess onto: marker.
+	answerProcess resize: answerProcess size + 1.
+	answerProcess at: answerProcess size put: anObject.
+	answerProcess topFrame sp: answerProcess size.
+	answerProcess resume]
+			forkAt: Processor highIOPriority.!
+
+valueWithArguments: anArray 
+	^anArray size = 1 
+		ifTrue: [self value: anArray first]
+		ifFalse: [self error: 'Continuations can only be resumed with one argument.']!
+
+valueWithPossibleArguments: anArray 
+	^self value: anArray first.! !
+!PartialContinuation categoriesFor: #initializeFrom:to:!pharo!public! !
+!PartialContinuation categoriesFor: #numArgs!pharo!public! !
+!PartialContinuation categoriesFor: #value!pharo!public! !
+!PartialContinuation categoriesFor: #value:!pharo!public! !
+!PartialContinuation categoriesFor: #valueWithArguments:!pharo!public! !
+!PartialContinuation categoriesFor: #valueWithPossibleArguments:!pharo!public! !
+
+!PartialContinuation class methodsFor!
+
+currentDo: aBlock
+	| marker |
+	marker := ContinuationDelimiterRequest signal
+				ifNil: [self error: 'Delimiter not found when capturing partial continuation.'].
+	^aBlock value: (self from: Processor activeProcess topFrame sender to: marker).!
+
+from: aSourceContext to: aTargetContext 
+	^self basicNew initializeFrom: aSourceContext to: aTargetContext.! !
+!PartialContinuation class categoriesFor: #currentDo:!public! !
+!PartialContinuation class categoriesFor: #from:to:!public! !
+

--- a/Daniel S/PartialContinuationTest.cls
+++ b/Daniel S/PartialContinuationTest.cls
@@ -1,0 +1,281 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+TestCase subclass: #PartialContinuationTest
+	instanceVariableNames: 'crossKK counter'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+PartialContinuationTest guid: (GUID fromString: '{3e537595-6fc5-4387-9c87-d310adde82f3}')!
+PartialContinuationTest comment: ''!
+!PartialContinuationTest categoriesForClass!Unclassified! !
+!PartialContinuationTest methodsFor!
+
+crossProcessExpiredInner
+	self 
+		assert: (self mark: [2 * (self callcc: 
+									[:cc | 
+									crossKK := cc.
+									2])]) 
+				= 4.!
+
+ensureWithReturnInner: kk 
+	^self mark: [[kk value: 3] ensure: [^0]].!
+
+ensureWithReturnNotVeryFarInner: kk 
+	[kk value: 3] ensure: [^0].!
+
+markWithCounter: aBlock
+	| answer |
+	answer := aBlock on: ContinuationDelimiterRequest
+				do: 
+					[:ex |
+					ex resume: Processor activeProcess topFrame homeFrame.
+					^self].
+	counter ifNil: [counter := 1] ifNotNil: [counter := counter + 1].
+	^answer.!
+
+testCrossProcess
+	| k1 k2 sem |
+	sem := Semaphore new.
+	
+	[self 
+		assert: (self mark: 
+					[2 
+						* (self callcc: 
+									[:c1 | 
+									k1 := c1.
+									3 * (self callcc: 
+													[:c2 | 
+													k2 := c2.
+													4])])]) 
+				= 24.
+	sem signal] 
+			fork.
+	sem wait.
+	
+	[self assert: (self mark: [k1 value: 5]) = 10.
+	sem signal] fork.
+	sem wait.
+	
+	[self assert: (self mark: [k2 value: 5]) = 30.
+	sem signal] fork.
+	sem wait.!
+
+testCrossProcessExpired
+	| sem |
+	sem := Semaphore new.
+	
+	[self crossProcessExpiredInner.
+	sem signal] fork.
+	sem wait.
+	self assert: (self mark: [crossKK value: 3]) = 6.
+	self assert: (self mark: [crossKK value: 4]) = 8.
+	self assert: (self mark: [crossKK value: 5]) = 10.!
+
+testEnsureInsideContinuation
+	" ensure blocks within the continuation should be unwound as well "
+
+	| kk count |
+	count := 0.
+	Transcript
+		display: Processor activeProcess topFrame index;
+		tab;
+		display: Processor activeProcess topFrame sp;
+		cr.
+	self 
+		mark: [[2 * (self callcc: 
+							[:cc | 
+							kk := cc.
+							0])] ensure: [count := count + 1]].
+	self assert: count = 1.
+	self assert: (kk value: 2) = 4.
+	self assert: count = 2.
+	self assert: (kk value: 3) = 6.
+	self assert: count = 3!
+
+testEnsureOutsideContinuation
+	" before evaluation, ensure blocks should be unwound "
+
+	| kk count |
+	count := 0.
+	self mark: [2 * (self callcc: 
+							[:cc | 
+							kk := cc.
+							0])].
+	self assert: (self mark: [[kk value: 3] ensure: [count := count + 1]]) = 6.
+	self assert: count = 1!
+
+testEnsureWithReturn
+	" ensure blocks should be unwound--the question is, how far? Should an ensure block that attempts to return past the mark context be allowed to do so? In Pharo the answer is 'yes' so going with that "
+
+	| kk |
+	self mark: [2 * (self callcc: 
+							[:cc |
+							kk := cc.
+							0])].
+	self assert: (self ensureWithReturnInner: kk) = 0.
+	self
+		assert: ((Process primAllInstances select: [:each | each name = (PartialContinuation >> #value:)])
+				allSatisfy: [:each | each state = #dead]).
+	MemoryManager current compact.
+	self
+		assert: (Process primAllInstances select: [:each | each name = (PartialContinuation >> #value:)])
+				isEmpty.!
+
+testEnsureWithReturnNotVeryFar
+	"If an ensure block does a non-local return that doesn't overshoot, we should still run the PartialContinuation"
+
+	| kk |
+	self mark: [2 * (self callcc: 
+							[:cc | 
+							kk := cc.
+							0])].
+	"Here the continuation will patch itself on top of the ensure block, so the ensure will ultimately govern what is returned."
+	self assert: (self ensureWithReturnNotVeryFarInner: kk) = 0.
+	"Here the ensure will be executed for any side effects it might have,
+	but the non-local return it contains won't really affect control flow since it doesn't return past the mark:"
+	self assert: (self mark: [self ensureWithReturnNotVeryFarInner: kk]) = 6.!
+
+testExceptionHandling
+	| kk |
+	self 
+		assert: (
+			[self mark: 
+					[| value |
+					value := [self callcc: 
+									[:cc | 
+									kk := cc.
+									Warning signal + 4]] 
+								on: Warning
+								do: [:ex | ex resume: 9].
+					Warning signal + value]] 
+					on: Warning
+					do: [:ex | ex resume: 7]) = 20.
+	self assert: ([self mark: [kk value: 1]] on: Warning do: [:ex | ex resume: 2]) = 3!
+
+testIfCurtailedThenSignal
+	"ProcessPatcher>>unwindExistingStack is very sensitive to this method being defined Just So..."
+
+	self assert: (BlockClosure >> #ifCurtailed:thenSignal:) byteCodes 
+				= (Compiler 
+						compile: 'ifCurtailed: handlerBlock thenSignal: aSemaphore
+^self valueOnUnwind: [:retValue :retFrame | handlerBlock ensure: [aSemaphore signal]]'
+						in: BlockClosure) byteCodes.!
+
+testMarkerOnValue
+	| kk captured seen |
+	captured := false.
+	seen := false.
+	self shouldnt: 
+			[self mark: 
+					[| value |
+					value := self callcc: 
+									[:cc | 
+									kk := cc.
+									captured := true].
+					seen := true.
+					value]]
+		raise: Error.
+	self assert: captured.
+	self assert: seen.
+	captured := false.
+	seen := false.
+	"Make sure the marker method is not included in the continuation and the continuation returns directly
+	into the marker method."
+	self assert: (self mark: 
+					[kk value: 123.
+					456]) = 123.
+	self deny: captured.
+	self assert: seen!
+
+testMarkFrameIsNotDuplicated
+	| kk |
+	self markWithCounter: [2 * (self callcc: 
+							[:cc | 
+							kk := cc.
+							0])].
+	self assert: counter = 1.
+	self assert: (self markWithCounter: [kk value: 3]) = 6.
+	self assert: counter = 2.!
+
+testNestedEvaluation
+	| k1 k2 |
+	self 
+		assert: (self mark: 
+					[2 
+						* (self callcc: 
+									[:c1 | 
+									k1 := c1.
+									3 * (self callcc: 
+													[:c2 | 
+													k2 := c2.
+													4])])]) 
+				= 24.
+	self assert: (self mark: [k1 value: 5]) = 10.
+	self assert: (self mark: [k2 value: 5]) = 30.!
+
+testNoMarkerOnCall
+	| captured seen |
+	captured := false.
+	seen := false.
+	self should: 
+			[self callcc: [:cc | captured := true].
+			seen := true]
+		raise: Error.
+	self deny: captured.
+	self deny: seen.!
+
+testNoMarkerOnValue
+	| kk captured seen |
+	captured := false.
+	seen := false.
+	self mark: 
+			[| value |
+			value := self callcc: 
+							[:cc | 
+							kk := cc.
+							captured := true].
+			seen := true.
+			value].
+	self assert: captured.
+	self assert: seen.
+	captured := false.
+	seen := false.
+	"Make sure the marker method was not included in the continuation"
+	self assert: (kk value: 123) = 123.
+	self deny: captured.
+	self assert: seen!
+
+testReentrant
+	| kk |
+	self 
+		assert: (self mark: [2 * (self callcc: 
+									[:cc | 
+									kk := cc.
+									2])]) = 4.
+	self assert: (self mark: [kk value: 3]) = 6.
+	self assert: (self mark: [kk value: 4]) = 8.
+	self assert: (self mark: [kk value: 5]) = 10!
+
+testSimple
+	self assert: (self mark: [self callcc: [:cc | cc value: true]])! !
+!PartialContinuationTest categoriesFor: #crossProcessExpiredInner!public! !
+!PartialContinuationTest categoriesFor: #ensureWithReturnInner:!public! !
+!PartialContinuationTest categoriesFor: #ensureWithReturnNotVeryFarInner:!public! !
+!PartialContinuationTest categoriesFor: #markWithCounter:!public! !
+!PartialContinuationTest categoriesFor: #testCrossProcess!public! !
+!PartialContinuationTest categoriesFor: #testCrossProcessExpired!public! !
+!PartialContinuationTest categoriesFor: #testEnsureInsideContinuation!public! !
+!PartialContinuationTest categoriesFor: #testEnsureOutsideContinuation!public! !
+!PartialContinuationTest categoriesFor: #testEnsureWithReturn!public! !
+!PartialContinuationTest categoriesFor: #testEnsureWithReturnNotVeryFar!public! !
+!PartialContinuationTest categoriesFor: #testExceptionHandling!public! !
+!PartialContinuationTest categoriesFor: #testIfCurtailedThenSignal!public! !
+!PartialContinuationTest categoriesFor: #testMarkerOnValue!public! !
+!PartialContinuationTest categoriesFor: #testMarkFrameIsNotDuplicated!public! !
+!PartialContinuationTest categoriesFor: #testNestedEvaluation!public! !
+!PartialContinuationTest categoriesFor: #testNoMarkerOnCall!public! !
+!PartialContinuationTest categoriesFor: #testNoMarkerOnValue!public! !
+!PartialContinuationTest categoriesFor: #testReentrant!public! !
+!PartialContinuationTest categoriesFor: #testSimple!public! !
+

--- a/Daniel S/PartialProcessCopier.cls
+++ b/Daniel S/PartialProcessCopier.cls
@@ -1,0 +1,83 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+AbstractPartialProcessCopier subclass: #PartialProcessCopier
+	instanceVariableNames: 'topFrame'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+PartialProcessCopier guid: (GUID fromString: '{7c851762-ac1f-4cd5-be37-4e777f9ec4a6}')!
+PartialProcessCopier comment: ''!
+!PartialProcessCopier categoriesForClass!Unclassified! !
+!PartialProcessCopier methodsFor!
+
+copyStackFrom: inputTopFrame to: inputBaseFrame 
+	topFrame := inputTopFrame.
+	baseFrame := inputBaseFrame.
+	source := topFrame process.
+	clone := source shallowCopy postCopy.
+	seamIndex := baseFrame bp - 2.
+	delta := (clone spOfIndex: 1) - (baseFrame basicBP - 2).	"i.e. (source spOfIndex: baseFrame bp - 1) -- but this is faster"
+	self
+		createBasicCopyOfStack;
+		initializeCopiedMap;
+		initializeIndexMap;
+		cutOffExceptionHandlers;
+		patchFrames;
+		patchStackSlots;
+		patchExceptionHandlers.
+	"The clone is not yet valid and should *not* be finalizable (it will crash the VM on unwind). Just return it"
+	^clone.!
+
+createBasicCopyOfStack
+	1 to: topFrame sp - seamIndex do: [:i | clone at: i put: (clone at: seamIndex + i)].
+	(clone frameAtIndex: baseFrame index - seamIndex) basicSender: 0.
+	clone
+		resize: topFrame sp - seamIndex;
+		suspendedFrame: topFrame index - seamIndex;
+		name: 'Partial copy of ' , source id printString , ':' , source name displayString!
+
+cutOffExceptionHandlers
+	| exceptionHandler |
+	exceptionHandler := source exceptionEnvironment.
+	exceptionHandler ifNil: [^self].
+	exceptionHandler outer ifNil: [copied at: exceptionHandler put: ExceptionHandlerChainCookie].
+	
+	[| correspondingSourceFrame |
+	correspondingSourceFrame := source
+				frameAtAddress: (exceptionHandler instVarNamed: 'returnContinuation') home outer.
+	correspondingSourceFrame sender homeFrame index >= baseFrame index]
+			whileTrue: [exceptionHandler := exceptionHandler outer].
+	copied at: exceptionHandler put: ExceptionHandlerChainCookie.!
+
+initializeIndexMap
+	indexMap := IdentityDictionary new.
+	1 to: seamIndex
+		do: [:i | (source at: i) ifNotNil: [:a | a isInteger ifFalse: [indexMap at: a put: i]]]!
+
+patchFrames
+	| copyFrame |
+	copyFrame := clone suspendedFrame.
+	[copyFrame isNil] whileFalse: 
+			[copyFrame rebase: self.
+			copyFrame := copyFrame sender]!
+
+patchStackSlots
+	1 to: clone size
+		do: 
+			[:i | 
+			| each |
+			each := source at: i + seamIndex.
+			each isInteger ifFalse: [clone at: i put: (self visit: each)]]! !
+!PartialProcessCopier categoriesFor: #copyStackFrom:to:!public! !
+!PartialProcessCopier categoriesFor: #createBasicCopyOfStack!copying!private! !
+!PartialProcessCopier categoriesFor: #cutOffExceptionHandlers!public! !
+!PartialProcessCopier categoriesFor: #initializeIndexMap!public! !
+!PartialProcessCopier categoriesFor: #patchFrames!copying!private! !
+!PartialProcessCopier categoriesFor: #patchStackSlots!copying!private! !
+
+!PartialProcessCopier class methodsFor!
+
+copyStackFrom: topFrame to: bottomFrame 
+	^self new copyStackFrom: topFrame to: bottomFrame! !
+!PartialProcessCopier class categoriesFor: #copyStackFrom:to:!public! !
+

--- a/Daniel S/ProcessPatcher.cls
+++ b/Daniel S/ProcessPatcher.cls
@@ -1,0 +1,178 @@
+"Filed out from Dolphin Smalltalk 7"!
+
+AbstractPartialProcessCopier subclass: #ProcessPatcher
+	instanceVariableNames: 'patchFrames'
+	classVariableNames: ''
+	poolDictionaries: ''
+	classInstanceVariableNames: ''!
+ProcessPatcher guid: (GUID fromString: '{dcafe68c-9699-4132-aeea-3a66c4e53de9}')!
+ProcessPatcher comment: ''!
+!ProcessPatcher categoriesForClass!Unclassified! !
+!ProcessPatcher methodsFor!
+
+findMethodContextForBlock: aBlock beforeFrame: aStackFrame 
+	#deprecated.
+	"| currentFrame |
+	currentFrame := aStackFrame.
+	[currentFrame notNil] whileTrue: 
+			[(currentFrame method = aBlock method 
+				and: [currentFrame environment class = Context and: [currentFrame environment block isNil]]) 
+					ifTrue: [^currentFrame environment].
+			currentFrame := currentFrame sender].
+	self error: 'Couldn''t find plausible Context for ' , aBlock displayString."!
+
+fixOuterForBlock: aBlock beforeFrame: aStackFrame 
+	#deprecated.
+	"aBlock outer = nil | (aBlock outer = 0) | (fixedBlocks includes: aBlock) ifTrue: [^self].
+	aBlock outer block 
+		ifNotNil: [:outerBlock | ^self fixOuterForBlock: outerBlock beforeFrame: aStackFrame].
+	aBlock outer: (self findMethodContextForBlock: aBlock beforeFrame: aStackFrame).
+	fixedBlocks add: aBlock."!
+
+initializeIndexMap
+	indexMap := IdentityDictionary new.
+	1 to: seamIndex
+		do: [:i | (clone at: i) ifNotNil: [:a | a isInteger ifFalse: [indexMap at: a put: i]]]!
+
+pasteBasicCopyOfStack
+	| firstPastedFrame |
+	clone resize: seamIndex + source size.
+	1 to: source size
+		do: 
+			[:i | 
+			| srcVal |
+			srcVal := source at: i.
+			srcVal isInteger ifFalse: [srcVal := self visit: srcVal].
+			clone at: seamIndex + i put: srcVal].
+	firstPastedFrame := clone frameAtIndex: seamIndex + patchFrames first index.
+	firstPastedFrame sender: baseFrame.
+	firstPastedFrame basicSender: firstPastedFrame basicSender - delta.	"Have to intentionally break this frame so that when patchFrames fixes it the result is what we want"
+	clone suspendedFrame: (clone frameAtIndex: source topFrame index + seamIndex)!
+
+patch: aPartialProcess onto: aStackFrame 
+	baseFrame := aStackFrame sender.	"??? Need to avoid ending up with duplicate stack frames?"
+	source := aPartialProcess.
+	clone := baseFrame process.
+	seamIndex := baseFrame sp.
+	patchFrames := (source stackFramesFrom: source topFrame depth: SmallInteger maximum) reverse.
+	delta := baseFrame basicSP + 2 - (source spOfIndex: 1).
+	""
+	self
+		unwindExistingStack;
+		initializeCopiedMap;
+		initializeIndexMap;
+		patchExceptionHandlers;
+		pasteBasicCopyOfStack;
+		patchFrames.	";
+		patchContexts."
+	(clone name displayString findString: 'Patched') == 0 
+		ifTrue: [clone name: 'Patched ' , clone name displayString].!
+
+patchContexts
+	#deprecated.
+	"Seems to be obsoleted by reusing things that first came into existence outside the continuation...but you never know..."
+
+	"fixedBlocks := IdentitySet new.
+	patchFrames do: 
+			[:sourceFrame | 
+			| targetFrame |
+			targetFrame := clone frameAtIndex: sourceFrame index + seamIndex.
+			targetFrame bp - 1 to: targetFrame sp
+				do: 
+					[:i | 
+					| block |
+					block := clone at: i.
+					block class = BlockClosure ifTrue: [self fixOuterForBlock: block beforeFrame: targetFrame]]]."!
+
+patchExceptionHandlers
+	copied at: ExceptionHandlerChainCookie put: clone exceptionEnvironment.
+	super patchExceptionHandlers.!
+
+patchFrames
+	| copyFrame |
+	copyFrame := clone suspendedFrame.
+	[copyFrame notNil and: [copyFrame index > seamIndex]] whileTrue: 
+			[copyFrame rebase: self.
+			copyFrame := copyFrame sender]!
+
+unwindExistingStack
+	| frame |
+	frame := clone suspendedFrame.
+	[frame index > baseFrame index] whileTrue: 
+			["Magic index--this is the special marker block used by #valueOnUnwind:."
+			frame receiver == (VMLibrary default registry at: 115)
+				ifTrue: 
+					[| protectedBlock handlerBlock valueOnUnwindBlock newFrame semaphore offsetFrame |
+					self assert: 
+							[frame method = (BlockClosure >> #ifCurtailed:)
+								and: [frame environment isNil or: [frame environment isZero]]].
+					protectedBlock := clone at: frame sp + 1.
+					handlerBlock := frame argAt: 1.
+					valueOnUnwindBlock := clone at: frame sp + 2.
+					semaphore := Semaphore new.
+					""
+					clone resize: frame sp + 12.	"Trust me, it works (I think :))"
+					""
+					offsetFrame := clone frameAtIndex: frame index + 1.
+					offsetFrame bp: frame bp.
+					offsetFrame sp: frame sp + 1.
+					offsetFrame sender: frame sender.
+					offsetFrame environment: 0.
+					offsetFrame method: BlockClosure >> #ifCurtailed:thenSignal:.
+					offsetFrame at: 2 put: semaphore.
+					"offsetFrame at: 1 put: ifCurtailedBlock."	"Already there"
+					offsetFrame receiver: protectedBlock.
+					"Last instruction of #ifCurtailed:thenSignal:, which is bigger than regular #ifCurtailed:"
+					offsetFrame ip: 25.
+					""
+					newFrame := clone frameAtIndex: offsetFrame sp + 6.
+					newFrame method: BlockClosure >> #ifCurtailed:thenSignal:.
+					"One higher than the equivalent in #ifCurtailed: because of the extra arg"
+					valueOnUnwindBlock initialIP: 10.
+					valueOnUnwindBlock method: BlockClosure >> #ifCurtailed:thenSignal:.
+					newFrame environment: valueOnUnwindBlock.
+					newFrame sender: offsetFrame.
+					newFrame ip: valueOnUnwindBlock initialIP.
+					newFrame sp: clone size.
+					newFrame bp: offsetFrame sp + 2.
+					"Doesn't matter, no references to it, but I think this is correct"
+					newFrame receiver: protectedBlock receiver.
+					newFrame at: 1 put: nil.
+					"Again, doesn't matter, but technically the baseFrame is where we're trying to 'return' to"
+					newFrame at: 2 put: baseFrame index.
+					newFrame at: 3 put: semaphore.
+					newFrame at: 4 put: handlerBlock.
+					clone suspendedFrame: newFrame.
+					""
+					clone resume.
+					semaphore wait.
+					clone suspend.
+					frame := clone topFrame.
+					"If the unwind overshot the frame we're trying to patch onto,
+					just abandon the patch attempt (this is what Pharo seems to do...)"
+					(frame sender method = (BlockClosure >> #ifCurtailed:) and: [(frame sender at: 2) < baseFrame index])
+						ifTrue: 
+							[clone resume.
+							Processor terminateActive]]
+				ifFalse: 
+					["Expire method contexts we're unwinding past. I think this is correct..."
+					(frame environment class = Context and: [frame environment outer isInteger])
+						ifTrue: [frame environment outer: 0].
+					clone suspendedFrame: (frame := frame sender)]].
+	self assert: [clone suspendedFrame = baseFrame].! !
+!ProcessPatcher categoriesFor: #findMethodContextForBlock:beforeFrame:!obsolete!public! !
+!ProcessPatcher categoriesFor: #fixOuterForBlock:beforeFrame:!obsolete!private! !
+!ProcessPatcher categoriesFor: #initializeIndexMap!public! !
+!ProcessPatcher categoriesFor: #pasteBasicCopyOfStack!public! !
+!ProcessPatcher categoriesFor: #patch:onto:!public! !
+!ProcessPatcher categoriesFor: #patchContexts!obsolete!private! !
+!ProcessPatcher categoriesFor: #patchExceptionHandlers!public! !
+!ProcessPatcher categoriesFor: #patchFrames!copying!public! !
+!ProcessPatcher categoriesFor: #unwindExistingStack!public! !
+
+!ProcessPatcher class methodsFor!
+
+patch: aPartialProcess onto: aStackFrame 
+	^self new patch: aPartialProcess onto: aStackFrame! !
+!ProcessPatcher class categoriesFor: #patch:onto:!public! !
+

--- a/Daniel S/README.md
+++ b/Daniel S/README.md
@@ -1,0 +1,3 @@
+# Contributions
+- DS Partial Continuations: A Seaside-compatible implementation of Partial Continuations for Dolphin.
+- Seaside-Dolphin-Flow: The couple glue methods that actually make Seaside use the above. Note, you will get a "Package contents clash" error when loading this with Seaside installed, as the existing Grease-Dolphin-Core currently includes an "Error notYetImplemented" stub for one of these methods.

--- a/Daniel S/Seaside-Dolphin-Flow.pax
+++ b/Daniel S/Seaside-Dolphin-Flow.pax
@@ -1,0 +1,73 @@
+| package |
+package := Package name: 'Seaside-Dolphin-Flow'.
+package paxVersion: 1;
+	basicComment: 'Copyright (c) 2014 Daniel Slomovits. Portions copyright (c) 2014 Shoshana Technologies, Inc., released with permission.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.'.
+
+
+package methodNames
+	add: #GRDolphinPlatform -> #seasideCallbackDelimiter;
+	add: #GRDolphinPlatform -> #seasideSuspendFlowDo:;
+	yourself.
+
+package binaryGlobalNames: (Set new
+	yourself).
+
+package globalAliases: (Set new
+	yourself).
+
+package setPrerequisites: (IdentitySet new
+	add: '..\..\Core\Object Arts\Dolphin\Base\Dolphin';
+	add: 'DS Partial Continuations';
+	add: '..\..\Seaside30\Grease\Grease-Dolphin-Core';
+	add: '..\..\Seaside30\Seaside\Seaside-Component';
+	add: '..\..\Seaside30\Seaside\Seaside-Core';
+	yourself).
+
+package!
+
+"Class Definitions"!
+
+
+"Global Aliases"!
+
+
+"Loose Methods"!
+
+!GRDolphinPlatform methodsFor!
+
+seasideCallbackDelimiter
+	| context |
+	context := Processor activeProcess topFrame sender.
+	
+	[context isNil
+		or: [(context receiver isKindOf: WACallback) or: [context method == (WATaskVisitor >> #visitTask:)]]]
+			whileFalse: [context := context sender].
+	context isNil
+		ifTrue: [self error: 'You can only #call: and #answer: from within a callback or a Task.'].
+	^context.!
+
+seasideSuspendFlowDo: aBlock
+	"Evaluate aBlock, passing in a continuation that can be evaluated to answer to the place where this very method was called. This method is presumed to be executed only within the scope of an executing Callback or Task and should, ideally, create a continuation that includes only the contexts that make up the Callback or Task execution (a partial or delimited continuation). Do not use this method, if you don't understand this comment."
+
+	"^Error notYetImplemented."
+
+	"^AnswerContinuation currentDo: aBlock."
+
+	| continuation |
+	continuation := PartialContinuation from: Processor activeProcess topFrame sender
+				to: self seasideCallbackDelimiter.
+	^aBlock value: 
+			[:answer |
+			[continuation value: answer] on: ContinuationDelimiterRequest
+				do: [:request | request resume: self seasideCallbackDelimiter]].! !
+!GRDolphinPlatform categoriesFor: #seasideCallbackDelimiter!public! !
+!GRDolphinPlatform categoriesFor: #seasideSuspendFlowDo:!public! !
+
+"End of package definition"!
+


### PR DESCRIPTION
I wrote this a while ago and never actually used it for anything—seems like something the community might be interested in. It works for Seaside in my (limited) testing, but I'm sure there are edge cases that aren't handled properly. I'd really appreciate review by someone with more knowledge of the inner workings of the VM—I'm interested to know what you think, what I missed, etc.

In particular, everything to do with exceptions is messy and arcane, and I don't think it quite works right in the case of capturing a continuation inside an exception handler block.
* To be honest, I no longer fully understand the process of cutting and reconnecting the chain of exception handlers, though I expect I could figure it back out in an hour or two.
* In particular, I seem to need a "cookie" object _with particular behavior_ (how it interacts with the ProcessCopier). Right now I'm just abusing a Class—I could use a singleton instance thereof instead, but I can't help but think I'm missing something and could avoid creating a special object altogether.
* The fact that `Exception`s clear so much information when copied is a bit of a nuisance, which I hacked around with a special #copyForProcessCopier method. It seems like the addition of `Exception._process` might warrant rethinking that copy behavior, but I really have no idea of the implications...