### PR TITLE
Fix for PartialContinuation issues highlighted by Seaside tests

### DIFF
--- a/Daniel S/DS Partial Continuations.pax
+++ b/Daniel S/DS Partial Continuations.pax
@@ -1,4 +1,4 @@
-| package |
+﻿| package |
 package := Package name: 'DS Partial Continuations'.
 package paxVersion: 1;
 	basicComment: 'Partial Continuations support for Dolphin Smalltalk
@@ -18,7 +18,6 @@ package classNames
 	add: #ContinuationDelimiterRequest;
 	add: #ExceptionHandlerChainCookie;
 	add: #PartialContinuation;
-	add: #PartialContinuationTest;
 	add: #PartialProcessCopier;
 	add: #ProcessPatcher;
 	yourself.
@@ -34,6 +33,7 @@ package methodNames
 	add: #Object -> #mark:;
 	add: #Process -> #copyFrom:to:;
 	add: #Process -> #fixSuspendedFrame;
+	add: #Process -> #stackFramesFrom:depth:;
 	add: #StackFrame -> #receiver:;
 	yourself.
 
@@ -44,9 +44,8 @@ package globalAliases: (Set new
 	yourself).
 
 package setPrerequisites: (IdentitySet new
-	add: '..\..\Core\Object Arts\Dolphin\Base\Dolphin';
-	add: '..\..\Core\Object Arts\Dolphin\System\Continuations\Dolphin Continuations';
-	add: '..\..\Core\Contributions\Camp Smalltalk\SUnit\SUnit';
+	add: '..\Core\Object Arts\Dolphin\Base\Dolphin';
+	add: '..\Core\Object Arts\Dolphin\System\Continuations\Dolphin Continuations';
 	yourself).
 
 package!
@@ -80,11 +79,6 @@ AbstractPartialProcessCopier subclass: #PartialProcessCopier
 	classInstanceVariableNames: ''!
 AbstractPartialProcessCopier subclass: #ProcessPatcher
 	instanceVariableNames: 'patchFrames'
-	classVariableNames: ''
-	poolDictionaries: ''
-	classInstanceVariableNames: ''!
-TestCase subclass: #PartialContinuationTest
-	instanceVariableNames: 'crossKK counter'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -154,7 +148,7 @@ copyForProcessCopier
 mark: aBlock
 	| homeFrame |
 	homeFrame := Processor activeProcess topFrame.
-	^aBlock on: ContinuationDelimiterRequest do: [:ex | ex resume: homeFrame].! !
+	^aBlock on: PartialContinuation markerRequest do: [:ex | ex resume: homeFrame].! !
 !Object categoriesFor: #callcc:!public! !
 !Object categoriesFor: #copyForProcessCopier!public! !
 !Object categoriesFor: #mark:!public! !
@@ -174,9 +168,22 @@ fixSuspendedFrame
 	self
 		resize: sp;
 		at: sp put: self.
-	suspended sp: sp.! !
+	suspended sp: sp.!
+
+stackFramesFrom: aStackFrame depth: anInteger
+
+	| stackFrames frame |
+
+	stackFrames := OrderedCollection new: (anInteger min: 32).
+	frame := aStackFrame.
+	[frame isNil or: [stackFrames size = anInteger]] whileFalse: 
+		[stackFrames add: frame.
+		frame := frame sender].
+
+	^stackFrames! !
 !Process categoriesFor: #copyFrom:to:!public! !
 !Process categoriesFor: #fixSuspendedFrame!copying!public! !
+!Process categoriesFor: #stackFramesFrom:depth:!public! !
 
 !StackFrame methodsFor!
 

--- a/Daniel S/PartialContinuation.cls
+++ b/Daniel S/PartialContinuation.cls
@@ -36,7 +36,7 @@ value: anObject
 	answerProcess := marker process.
 	answerProcess suspend.
 	ProcessPatcher patch: partialProcess onto: marker.
-	answerProcess resize: answerProcess size " + 1 removed which broke WAFlowPlatrformTest>>testSuspendCallbackDo (incorrect receiver on resumption). All partial continuation-related tests run green without".
+	answerProcess resize: answerProcess size " + 1 removed which broke WAFlowPlatformTest>>testSuspendCallbackDo (incorrect receiver on resumption)".
 	answerProcess at: answerProcess size put: anObject.
 	answerProcess topFrame sp: answerProcess size.
 	"Useful for working out what's going on:

--- a/Daniel S/PartialContinuation.cls
+++ b/Daniel S/PartialContinuation.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #PartialContinuation
 	instanceVariableNames: 'partialProcess'
@@ -11,8 +11,16 @@ PartialContinuation comment: ''!
 !PartialContinuation methodsFor!
 
 initializeFrom: topFrame to: bottomFrame 
+
+	| actualBottomFrame |
+
+	"Note bottomFrame is *not* copied - this matches behavior of Pharo equivalent method captureFrom:to:
+	This means we have to find the frame whose sender is bottomFrame - this is the actual last frame we copy"
+	actualBottomFrame := topFrame.
+	[actualBottomFrame sender = bottomFrame] whileFalse: [actualBottomFrame := actualBottomFrame sender].
+
 	self initialize.
-	partialProcess := topFrame process copyFrom: topFrame to: bottomFrame!
+	partialProcess := topFrame process copyFrom: topFrame to: actualBottomFrame!
 
 numArgs
 	^1.!
@@ -22,42 +30,50 @@ value
 
 value: anObject
 	| marker |
-	marker := ContinuationDelimiterRequest signal ifNil: [Processor activeProcess topFrame sender].
+	marker := self class markerRequest signal ifNil: [Processor activeProcess topFrame sender].
 	
 	[| answerProcess |
 	answerProcess := marker process.
 	answerProcess suspend.
 	ProcessPatcher patch: partialProcess onto: marker.
-	answerProcess resize: answerProcess size + 1.
+	answerProcess resize: answerProcess size " + 1 removed which broke WAFlowPlatrformTest>>testSuspendCallbackDo (incorrect receiver on resumption). All partial continuation-related tests run green without".
 	answerProcess at: answerProcess size put: anObject.
 	answerProcess topFrame sp: answerProcess size.
+	"Useful for working out what's going on:
+		answerProcess topFrame stackTrace: 999
+		answerProcess debug"
 	answerProcess resume]
 			forkAt: Processor highIOPriority.!
 
 valueWithArguments: anArray 
 	^anArray size = 1 
 		ifTrue: [self value: anArray first]
-		ifFalse: [self error: 'Continuations can only be resumed with one argument.']!
-
-valueWithPossibleArguments: anArray 
-	^self value: anArray first.! !
+		ifFalse: [self error: 'Continuations can only be resumed with one argument.']! !
 !PartialContinuation categoriesFor: #initializeFrom:to:!pharo!public! !
 !PartialContinuation categoriesFor: #numArgs!pharo!public! !
 !PartialContinuation categoriesFor: #value!pharo!public! !
 !PartialContinuation categoriesFor: #value:!pharo!public! !
 !PartialContinuation categoriesFor: #valueWithArguments:!pharo!public! !
-!PartialContinuation categoriesFor: #valueWithPossibleArguments:!pharo!public! !
 
 !PartialContinuation class methodsFor!
 
 currentDo: aBlock
 	| marker |
-	marker := ContinuationDelimiterRequest signal
-				ifNil: [self error: 'Delimiter not found when capturing partial continuation.'].
+	marker := self markerRequest signal ifNil: [self markerNotFound].
 	^aBlock value: (self from: Processor activeProcess topFrame sender to: marker).!
 
 from: aSourceContext to: aTargetContext 
-	^self basicNew initializeFrom: aSourceContext to: aTargetContext.! !
-!PartialContinuation class categoriesFor: #currentDo:!public! !
-!PartialContinuation class categoriesFor: #from:to:!public! !
+	^self basicNew initializeFrom: aSourceContext to: aTargetContext.!
+
+markerNotFound
+
+	self error: 'Delimiter not found when capturing partial continuation.'!
+
+markerRequest
+
+	^ContinuationDelimiterRequest! !
+!PartialContinuation class categoriesFor: #currentDo:!instance creation!public! !
+!PartialContinuation class categoriesFor: #from:to:!instance creation!private! !
+!PartialContinuation class categoriesFor: #markerNotFound!public! !
+!PartialContinuation class categoriesFor: #markerRequest!public! !
 

--- a/Daniel S/PartialContinuationTest.cls
+++ b/Daniel S/PartialContinuationTest.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 TestCase subclass: #PartialContinuationTest
 	instanceVariableNames: 'crossKK counter'
@@ -24,9 +24,16 @@ ensureWithReturnInner: kk
 ensureWithReturnNotVeryFarInner: kk 
 	[kk value: 3] ensure: [^0].!
 
+markDiscardingResultOf: aBlock
+	| home |
+
+	home := Processor activeProcess topFrame.
+
+	aBlock on: PartialContinuation markerRequest do: [ :request | request resume: home ]!
+
 markWithCounter: aBlock
 	| answer |
-	answer := aBlock on: ContinuationDelimiterRequest
+	answer := aBlock on: PartialContinuation markerRequest
 				do: 
 					[:ex |
 					ex resume: Processor activeProcess topFrame homeFrame.
@@ -188,6 +195,30 @@ testMarkerOnValue
 	self deny: captured.
 	self assert: seen!
 
+testMarkerOnValueDiscardingResult
+
+	"Previously-failing test from WAPartialContinuationTest>>testMarkerOnValue"
+
+	| kk captured seen |
+	captured := false.
+	seen := false.
+	self	shouldnt: [
+			self markDiscardingResultOf: [ | value |
+				value := self callcc: [ :cc | kk := cc. captured := true ].
+				seen := true.
+				value ] ]
+		raise: Error.
+		
+	self assert: captured.
+	self assert: seen.
+	captured := false.
+	seen := false.
+	"Make sure the marker method is not included in the continuation and the continuation returns directly
+	into the marker method."
+	self assert: (self mark: [ kk value: 123. 456 ]) = 123.
+	self deny: captured.
+	self assert: seen!
+
 testMarkFrameIsNotDuplicated
 	| kk |
 	self markWithCounter: [2 * (self callcc: 
@@ -246,6 +277,30 @@ testNoMarkerOnValue
 	self deny: captured.
 	self assert: seen!
 
+testNoMarkerOnValueDiscardingResult
+
+	"Copied from WAPartialContinuationTest>>testNoMarkerOnValue"
+
+	| kk captured seen |
+	captured := false.
+	seen := false.
+	self	shouldnt: [
+			self markDiscardingResultOf: [
+				| value |
+				value := self callcc: [ :cc | kk := cc. captured := true ].
+				seen := true.
+				value ] ]
+		raise: Error.
+		
+	self assert: captured.
+	self assert: seen.
+	captured := false.
+	seen := false.
+	"Make sure the marker method was not included in the continuation"
+	self assert: (kk value: 123) = 123.
+	self deny: captured.
+	self assert: seen!
+
 testReentrant
 	| kk |
 	self 
@@ -262,6 +317,7 @@ testSimple
 !PartialContinuationTest categoriesFor: #crossProcessExpiredInner!public! !
 !PartialContinuationTest categoriesFor: #ensureWithReturnInner:!public! !
 !PartialContinuationTest categoriesFor: #ensureWithReturnNotVeryFarInner:!public! !
+!PartialContinuationTest categoriesFor: #markDiscardingResultOf:!private! !
 !PartialContinuationTest categoriesFor: #markWithCounter:!public! !
 !PartialContinuationTest categoriesFor: #testCrossProcess!public! !
 !PartialContinuationTest categoriesFor: #testCrossProcessExpired!public! !
@@ -272,10 +328,12 @@ testSimple
 !PartialContinuationTest categoriesFor: #testExceptionHandling!public! !
 !PartialContinuationTest categoriesFor: #testIfCurtailedThenSignal!public! !
 !PartialContinuationTest categoriesFor: #testMarkerOnValue!public! !
+!PartialContinuationTest categoriesFor: #testMarkerOnValueDiscardingResult!public! !
 !PartialContinuationTest categoriesFor: #testMarkFrameIsNotDuplicated!public! !
 !PartialContinuationTest categoriesFor: #testNestedEvaluation!public! !
 !PartialContinuationTest categoriesFor: #testNoMarkerOnCall!public! !
 !PartialContinuationTest categoriesFor: #testNoMarkerOnValue!public! !
+!PartialContinuationTest categoriesFor: #testNoMarkerOnValueDiscardingResult!public! !
 !PartialContinuationTest categoriesFor: #testReentrant!public! !
 !PartialContinuationTest categoriesFor: #testSimple!public! !
 

--- a/Daniel S/ProcessPatcher.cls
+++ b/Daniel S/ProcessPatcher.cls
@@ -1,4 +1,4 @@
-"Filed out from Dolphin Smalltalk 7"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 AbstractPartialProcessCopier subclass: #ProcessPatcher
 	instanceVariableNames: 'patchFrames'
@@ -50,7 +50,11 @@ pasteBasicCopyOfStack
 	clone suspendedFrame: (clone frameAtIndex: source topFrame index + seamIndex)!
 
 patch: aPartialProcess onto: aStackFrame 
-	baseFrame := aStackFrame sender.	"??? Need to avoid ending up with duplicate stack frames?"
+
+	baseFrame := aStackFrame. 
+	"Previously baseFrame was 'aStackFrame sender' with the comment '??? Need to avoid ending up with duplicate stack frames?'
+	Stack capture has now been changed to be exclusive of 'to' frame (see PartialContinuation>>initializeFrom:to:) which has removed the need for sender"
+	
 	source := aPartialProcess.
 	clone := baseFrame process.
 	seamIndex := baseFrame sp.


### PR DESCRIPTION
Fix an issue highlighted by Seaside SUnit tests WAPartialContinuationTest>>testMarkerOnValue (included here as PartialContinuationTest>>testMarkerOnValueDiscardingResult) and WAFlowPlatformTest>>testSuspendCallbackDo (not included due to Seaside dependencies).
Also:
 - reinstate missing method Process>>stackFramesFrom:depth:
 - minor refactoring for easier subclassing in Seaside
 - move test class into separate package to avoid creating dependency on SUnit package